### PR TITLE
Make tag suggestion list scrollable

### DIFF
--- a/packages/landscaping-toolbox/src/components/tag-input/tag-input.css
+++ b/packages/landscaping-toolbox/src/components/tag-input/tag-input.css
@@ -156,6 +156,9 @@
     border: 1px solid #D1D1D1;
     border-radius: 2px;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    height:300px;
+    overflow:hidden; 
+    overflow-y:scroll;
 }
 
 .react-tags__suggestions li {


### PR DESCRIPTION
Locks the height of the suggestion box and makes the list scrollable to avoid extremely long lists.

